### PR TITLE
[FEATURE] Replace file extension instead of appending .webp

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ After:
 
 > npm i posthtml posthtml-webp
 
+## Plugin options
+`replaceExtension` (boolean)
+
+**Default:** false
+
+Replace the extension of the source image with .webp instead of appending .webp to the original filename
+
+**Example**: image.jpg => image.webp (instead of image.jpg.webp)
+
 ## Usage
 
 ``` js
@@ -34,7 +43,7 @@ const posthtml = require('posthtml');
 const posthtmlWebp = require('posthtml-webp');
 
 posthtml()
-    .use(posthtmlWebp())
+    .use(posthtmlWebp(/* Plugin options */))
     .process(html/*, options */)
     .then(result => fs.writeFileSync('./after.html', result.html));
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,43 @@
 'use strict'
 
-module.exports = function () {
+module.exports = function (options) {
+  if (!options) {
+    options = {}
+  }
+
+  if (options.replaceExtension === undefined) {
+    options.replaceExtension = false
+  }
+
   return function posthtmlWebp (tree) {
     tree.match({ tag: 'img' }, function (imgNode) {
       if (imgNode.skip) return imgNode
-      return getPicture(imgNode)
+      return getPicture(imgNode, options)
     })
 
     return tree
   }
 }
 
-function getPicture (imgNode) {
+function removeExtension (filename) {
+  var extIndex = filename.lastIndexOf('.')
+  if (extIndex === -1) {
+    // Filename has no extension
+    return filename
+  } else {
+    return filename.substring(0, extIndex)
+  }
+}
+
+function getPicture (imgNode, options) {
   imgNode.skip = true
+
+  var src = imgNode.attrs.src
+  if (options.replaceExtension) {
+    src = removeExtension(src)
+  }
+  src += '.webp'
+
   return {
     tag: 'picture',
     content: [
@@ -20,7 +45,7 @@ function getPicture (imgNode) {
         tag: 'source',
         attrs: {
           type: 'image/webp',
-          srcset: imgNode.attrs.src + '.webp'
+          srcset: src
         }
       },
       imgNode

--- a/test/fixtures/extension.expected.html
+++ b/test/fixtures/extension.expected.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+    <body>
+        <picture><source type="image/webp" srcset="photo.webp"><img src="photo.png"></picture>
+    </body>
+</html>

--- a/test/fixtures/extension.html
+++ b/test/fixtures/extension.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+    <body>
+        <img src="photo.png">
+    </body>
+</html>

--- a/test/fixtures/no-extension.expected.html
+++ b/test/fixtures/no-extension.expected.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+    <body>
+        <picture><source type="image/webp" srcset="photo.png.webp"><img src="photo.png"></picture>
+    </body>
+</html>

--- a/test/fixtures/no-extension.html
+++ b/test/fixtures/no-extension.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+    <body>
+        <img src="photo.png">
+    </body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -11,11 +11,17 @@ test('basic', (t) => {
   return compare(t, 'basic')
 })
 
-function compare (t, name) {
+test('Replace extension', (t) => {
+  return compare(t, 'extension', {
+    replaceExtension: true
+  })
+})
+
+function compare (t, name, options) {
   const html = readFileSync(path.join(fixtures, `${name}.html`), 'utf8')
   const expected = readFileSync(path.join(fixtures, `${name}.expected.html`), 'utf8')
 
-  return posthtml([plugin()])
+  return posthtml([plugin(options)])
     .process(html)
     .then((res) => t.truthy(res.html === expected))
 }

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,12 @@ test('Replace extension', (t) => {
   })
 })
 
+test('Append extension', (t) => {
+  return compare(t, 'no-extension', {
+    replaceExtension: false
+  })
+})
+
 function compare (t, name, options) {
   const html = readFileSync(path.join(fixtures, `${name}.html`), 'utf8')
   const expected = readFileSync(path.join(fixtures, `${name}.expected.html`), 'utf8')

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,10 @@ test('Append extension', (t) => {
   })
 })
 
+test('Default behaviour', (t) => {
+  return compare(t, 'no-extension')
+})
+
 function compare (t, name, options) {
   const html = readFileSync(path.join(fixtures, `${name}.html`), 'utf8')
   const expected = readFileSync(path.join(fixtures, `${name}.expected.html`), 'utf8')


### PR DESCRIPTION
Allow the user to have an image folder like:
```
img/
├── photo_1.jpg
├── photo_1.webp
├── photo_2.jpg
└── photo_2.webp
```

Instead of this (with the actual plugin):
```
img/
├── photo_1.jpg
├── photo_1.jpg.webp
├── photo_2.jpg
└── photo_2.jpg.webp
```

---

This feature is designed to be **backward compatible**.
In fact, if the user leaves the configuration as it is, the plugin wi continue working as usual.

But if the user wants this feature, he can pass to `posthtmlWebp` function, the options object `{ replaceExtension: true }`.