### PR TITLE
Feature/ignore extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Example: `image.jpg => image.webp (instead of image.jpg.webp)`
 Type: `Array<string>`  
 Default: `[]`  
 Description: *list of classes for which the transformation will be ignored*  
-Example: `image.jpg => image.webp (instead of image.jpg.webp)`
+Example: `classIgnore: ['ignore-webp']` will ignore transformation for images with the class `ignore-web` 
 
 #### `extensionIgnore`
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Default: `[]`
 Description: *list of classes for which the transformation will be ignored*  
 Example: `image.jpg => image.webp (instead of image.jpg.webp)`
 
+#### `extensionIgnore`
+
+Type: `Array<string>`  
+Default: `[]`  
+Description: *list of extension for which the transformation will be ignored*  
+Example: `extensionIgnore: ['svg']` will ignore transformation for images with the `svg` extension
+
 ### License [MIT](LICENSE)
 
 [npm]: https://img.shields.io/npm/v/posthtml-webp.svg

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,10 @@ module.exports = function (options) {
     options.classIgnore = []
   }
 
+  if (!options.extensionIgnore) {
+    options.extensionIgnore = []
+  }
+
   if (options.replaceExtension === undefined) {
     options.replaceExtension = false
   }
@@ -17,7 +21,10 @@ module.exports = function (options) {
     tree.match([{ tag: 'img' }, { tag: 'amp-img' }], function (imgNode) {
       if (imgNode.skip) return imgNode
       var classes = imgNode.attrs && imgNode.attrs.class && (imgNode.attrs.class.split(' ') || [])
-      var isIgnore = options.classIgnore.filter(className => classes.includes(className)).length > 0
+      var extension = imgNode.attrs.src.split('.').pop()
+      var isIgnore =
+        (options.classIgnore.filter(className => classes.includes(className)).length > 0) ||
+        (options.extensionIgnore.filter(fileExtension => fileExtension === extension).length > 0)
       if (isIgnore) return imgNode
       switch (imgNode.tag) {
         case 'amp-img':

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,11 +5,11 @@ module.exports = function (options) {
     options = {}
   }
 
-  if (!options.classIgnore) {
+  if (options.classIgnore === undefined) {
     options.classIgnore = []
   }
 
-  if (!options.extensionIgnore) {
+  if (options.extensionIgnore === undefined) {
     options.extensionIgnore = []
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,9 +22,9 @@ module.exports = function (options) {
       if (imgNode.skip) return imgNode
       var classes = imgNode.attrs && imgNode.attrs.class && (imgNode.attrs.class.split(' ') || [])
       var extension = imgNode.attrs.src.split('.').pop()
-      var isIgnore =
-        (options.classIgnore.filter(className => classes.includes(className)).length > 0) ||
-        (options.extensionIgnore.filter(fileExtension => fileExtension === extension).length > 0)
+      var isIgnoredByClass = options.classIgnore.filter(className => classes.includes(className)).length > 0
+      var isIgnoredByExtension = options.extensionIgnore.filter(fileExtension => fileExtension === extension).length > 0
+      var isIgnore = isIgnoredByClass || isIgnoredByExtension
       if (isIgnore) return imgNode
       switch (imgNode.tag) {
         case 'amp-img':

--- a/test/fixtures/ignore-extension.expected.html
+++ b/test/fixtures/ignore-extension.expected.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+    <body>
+        <img src="photo.svg">
+        <img src="photo.gif">
+        <picture><source type="image/webp" srcset="photo.jpg.webp"><img src="photo.jpg"></picture>
+        <picture><source type="image/webp" srcset="photo.png.webp"><img src="photo.png"></picture>
+    </body>
+</html>

--- a/test/fixtures/ignore-extension.html
+++ b/test/fixtures/ignore-extension.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+    <body>
+        <img src="photo.svg">
+        <img src="photo.gif">
+        <img src="photo.jpg">
+        <img src="photo.png">
+    </body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,12 @@ test('Class ignore', (t) => {
   })
 })
 
+test('Extension ignore', (t) => {
+  return compare(t, 'ignore-extension', {
+    extensionIgnore: ['gif', 'svg']
+  })
+})
+
 function compare (t, name, options) {
   const html = readFileSync(path.join(fixtures, `${name}.html`), 'utf8')
   const expected = readFileSync(path.join(fixtures, `${name}.expected.html`), 'utf8')


### PR DESCRIPTION
Added an option to ignore the transformation of images with the supplied list of extensions.

Usage:

```javascript
posthtmlWebp({ extensionIgnore: ['gif', 'svg'] })
```

* [x] Tests are written
* [x] Documentation added