### PR TITLE
Use unchanged <img> `srcset` as <source> `srcset`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,11 +76,9 @@ function getAmpPicture (imgNode, options) {
 
 function getPicture (imgNode, options) {
   imgNode.skip = true
-
-  var src = imgNode.attrs.src
-  var srcset = (imgNode.attrs.srcset || '')
+  // set <source> `srcset` to <img> `srcset`, if present; otherwise — use <img> `src`
+  var srcset = (imgNode.attrs.srcset || imgNode.attrs.src)
     .split(',')
-    .concat(src)
     .filter(Boolean)
     .map(value => {
       value = value.trim().split(/\s/)

--- a/test/fixtures/multisrcset.expected.html
+++ b/test/fixtures/multisrcset.expected.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
     <body>
-        <picture><source type="image/webp" srcset="photo-lg.webp 1000w, photo-md.webp 500w, photo-sm.webp 250w, photo.webp"><img srcset="photo-lg.jpg 1000w, photo-md.jpg 500w, photo-sm.jpg 250w" src="photo.png"></picture>
+        <picture><source type="image/webp" srcset="photo-lg.webp 1000w, photo-md.webp 500w, photo-sm.webp 250w, photo.webp"><img srcset="photo-lg.jpg 1000w, photo-md.jpg 500w, photo-sm.jpg 250w, photo.jpg" src="photo.png"></picture>
     </body>
 </html>

--- a/test/fixtures/multisrcset.html
+++ b/test/fixtures/multisrcset.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
     <body>
-        <img srcset="photo-lg.jpg 1000w, photo-md.jpg 500w, photo-sm.jpg 250w" src="photo.png">
+        <img srcset="photo-lg.jpg 1000w, photo-md.jpg 500w, photo-sm.jpg 250w, photo.jpg" src="photo.png">
     </body>
 </html>


### PR DESCRIPTION
To prevent unexpected behaviors transfer `srcset` from `<img>` to `<source>` exactly as-is, instead of always appending `src` value to `srcset`. In other words: keep `srcset` as it was originally defined 